### PR TITLE
DRUP-6: Add setup instructions for core module and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # sous
 A base Drupal distribution profile with a theme based on Emulsify with Gatsby.
+
+### Recommended Setup Actions:
+1) Consider using the [sous-project](https://github.com/fourkitchens/sous-project) repo for local setup and evaluation.
+2) Install a custom module at `/web/modules/custom/project_name_core` using drupal console, the documentation for the generate:module command is [here](https://hechoendrupal.gitbooks.io/drupal-console/en/commands/generate-module.html)
+3) Install your theme following the theme's setup instructions, the recommended naming for the theme is `/web/themes/custom/project_name_theme`


### PR DESCRIPTION
### Purpose:
- Add setup instructions for core module and theme

### JIRA:
- https://fourkitchens.atlassian.net/browse/DRUP-6

### Notes:
- The reason we went with drupal console is because drupal-scaffold only copies files and it can't alter anything.