### PR TITLE
Update emulsify package path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "npm-asset/imagesloaded": "^3.2.0",
         "bower-asset/masonry-layout": "^4.0.0",
         "npm-asset/slick": "^1.12",
-        "emulsify-ds/emulsify-design-system": "^1.0.0-alpha.5",
+        "emulsify-ds/emulsify-drupal": "^1.0.0-beta.2",
         "drupal/menu_block": "1.x-dev",
         "drupal/admin_toolbar": "2.x-dev"
     },


### PR DESCRIPTION
Fixes issue during composer install.

issue: https://www.drupal.org/project/sous/issues/3150326

> Package emulsify-ds/emulsify-design-system is abandoned, you should avoid using it. Use emulsify-ds/emulsify-drupal instead.