### PR TITLE
Fix: Setting D9 compatibility version number for Sous Admin install theme

### DIFF
--- a/themes/sous_admin/sous_admin.info.yml
+++ b/themes/sous_admin/sous_admin.info.yml
@@ -1,6 +1,6 @@
 name: Sous Admin
 type: theme
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 base theme: seven
 description: 'Admin theme for Sous; A Drupal distribution for custom projects with Emulsify.'
 


### PR DESCRIPTION
### Purpose:
Fix theme versioning so it's compatible with D9 without warnings.

### Testing
- Run a fresh install of Sous using the readme here:
- Log in and go to the appearance page (`/admin/appearance`) and verify this message is no longer present: "This theme is not compatible with Drupal 9.1.0. Check that the .info.yml file contains a compatible 'core' or 'core_version_requirement' value."
![Screen Shot 2021-01-08 at 2 50 18 PM](https://user-images.githubusercontent.com/369018/104063100-3b475280-51c1-11eb-862c-8a962ca82776.png)
