### PR TITLE
feat: Change the admin theme to Claro and remove thunder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "oomphinc/composer-installers-extender": "^2.0",
         "cweagans/composer-patches": "^1.6.5",
         "drupal/core": "^9.1.0",
-        "drupal/thunder_admin": "^4.0",
         "drupal/blazy": "^2.0",
         "drupal/allowed_formats": "^1.1",
         "drupal/easy_breadcrumb": "^1.12",

--- a/config/install/system.theme.yml
+++ b/config/install/system.theme.yml
@@ -1,1 +1,1 @@
-admin: thunder_admin
+admin: claro

--- a/sous.info.yml
+++ b/sous.info.yml
@@ -78,5 +78,5 @@ install:
 
 themes:
   - seven
-  - thunder_admin
+  - claro
   - sous_admin


### PR DESCRIPTION
## Change the admin theme to Claro and remove thunder

**This PR does the following:**
- Removed support for the [Thunder Admin theme](https://www.drupal.org/project/thunder_admin/)
- Installs the [Claro admin theme](https://www.drupal.org/project/claro)

**Notes:**
- Claro is a new core theme with a rigorously tested design system: https://www.drupal.org/docs/8/core/themes/claro-theme/design.
- Accessibility is a driving focus of Claro.
- The color palette is fairly neutral.
- Support and bug fixes will be bundled with core updates.