### PR TITLE
fix: admin_toolbar version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "npm-asset/slick": "^1.12",
         "emulsify-ds/emulsify-drupal": "^2.0.1",
         "drupal/menu_block": "1.x-dev",
-        "drupal/admin_toolbar": "2.x-dev"
+        "drupal/admin_toolbar": "^2.5"
     },
     "require-dev": {
         "symfony/var-dumper": "4.4.x-dev"


### PR DESCRIPTION
## Purpose:
- fix: admin_toolbar version
- security update: https://www.drupal.org/sa-contrib-2021-025

## Details:
- This PR make it easier to update admin toolbar since it was previous stuck to a dev version sites weren't recognizing the need to update the module