### PR TITLE
fix: libraries and masonry errors fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         }
     ],
     "require": {
+        "bower-asset/masonry-layout": "^4.0",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
         "drupal/admin_toolbar": "^2.5",
@@ -82,7 +83,8 @@
         "npm-asset/blazy": "^1.8",
         "npm-asset/dropzone": "^5.5.1",
         "npm-asset/imagesloaded": "^3.2.0",
-        "npm-asset/slick": "^1.12"
+        "npm-asset/slick": "^1.12",
+        "oomphinc/composer-installers-extender": "^2.0"
     },
     "require-dev": {
         "symfony/var-dumper": "4.4.x-dev"


### PR DESCRIPTION
## Purpose:
- Fix error preventing libraries from installing (missing composer-installers-extender package)
- Fix masonry library missing error
- This PR fixes the 2.x branch, Callin has fixes for these on the new 3.x branch