### PR TITLE
Change the admin theme to Gin and remove Claro

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "drupal/field_group": "^3.1",
         "drupal/file_browser": "^1.3",
         "drupal/focal_point": "^1.5",
+        "drupal/gin": "3.x-dev",
         "drupal/google_tag": "^1.4",
         "drupal/improve_line_breaks_filter": "^1.3",
         "drupal/libraries": "^3.0",
@@ -130,6 +131,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/config/install/system.theme.yml
+++ b/config/install/system.theme.yml
@@ -1,1 +1,1 @@
-admin: claro
+admin: gin

--- a/sous.info.yml
+++ b/sous.info.yml
@@ -83,5 +83,5 @@ install:
 
 themes:
   - seven
-  - claro
+  - gin
   - sous_admin


### PR DESCRIPTION
This PR does the following:

- Removed support for the [Claro Admin theme](https://www.drupal.org/project/claro/)
- Installs the [Gin admin theme](https://www.drupal.org/project/gin)

Notes:

- Gin is a new core theme with a rigorously tested design system: https://www.drupal.org/docs/8/core/themes/gin-theme/design.
- Accessibility is a driving focus of gin.
- The color palette is fairly neutral.
- Support and bug fixes will be bundled with core updates.

