### PR TITLE
Update login history to get the latest version starting at 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drupal/inline_entity_form": "1.0-rc11",
         "drupal/libraries": "^3.0",
         "drupal/linkit": "^6.0-beta3",
-        "drupal/login_history": "1.1-rc2",
+        "drupal/login_history": "^1.1",
         "drupal/menu_block": "1.x-dev",
         "drupal/metatag": "1.x-dev",
         "drupal/paragraphs": "^1.12",


### PR DESCRIPTION
This change updates the login-history to get the latest version starting at 1.1, previously it locked it into the `rc2` version