### PR TITLE
chore: remove default database password

### DIFF
--- a/sous.install
+++ b/sous.install
@@ -43,7 +43,6 @@ function sous_install() {
 function sous_form_install_settings_form_alter(&$form, FormStateInterface $form_state) {
   $form['settings']['mysql']['database']['#default_value'] = 'drupal9';
   $form['settings']['mysql']['username']['#default_value'] = 'drupal9';
-  $form['settings']['mysql']['password']['#placeholder'] = 'drupal9';
   $form['settings']['mysql']['advanced_options']['host']['#default_value'] = 'database';
 }
 


### PR DESCRIPTION
### Purpose
Remove default prefilled database from install page.

### Test
- [ ] Ensure the prefilled "drupal9" password does not exist in the database password field .